### PR TITLE
Add resources, reduce shutdown delay, use GS image catalog

### DIFF
--- a/helm/reports-server/templates/pg-cluster.yaml
+++ b/helm/reports-server/templates/pg-cluster.yaml
@@ -18,4 +18,16 @@ spec:
     {{- end}}
     grafanaDashboard:
       create: {{ .Values.postgres.cnpg.monitoring.grafanaDashboard.enabled }}
+
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ImageCatalog
+    major: {{ .Values.postgres.cnpg.imageCatalogRef.major }}
+    name: {{ .Values.postgres.cnpg.imageCatalogRef.name }}
+  
+  # Shutdown behavior is optimized for fast recovery time, at the expense of potential data loss.
+  smartShutdownTimeout: 180
+  stopDelay: 300
+  switchoverDelay: {{ .Values.postgres.cnpg.switchoverDelay }}
+
 {{- end -}}

--- a/helm/reports-server/templates/pg-cluster.yaml
+++ b/helm/reports-server/templates/pg-cluster.yaml
@@ -4,6 +4,8 @@ kind: Cluster
 metadata:
   name: {{ include "reports-server.fullname" . }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "reports-server.labels" . | nindent 4 }}
 spec:
   instances: {{ .Values.postgres.cnpg.instances }}
 
@@ -29,5 +31,4 @@ spec:
   smartShutdownTimeout: 180
   stopDelay: 300
   switchoverDelay: {{ .Values.postgres.cnpg.switchoverDelay }}
-
 {{- end -}}

--- a/helm/reports-server/templates/pg-cluster.yaml
+++ b/helm/reports-server/templates/pg-cluster.yaml
@@ -21,7 +21,7 @@ spec:
 
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
-    kind: ImageCatalog
+    kind: ClusterImageCatalog
     major: {{ .Values.postgres.cnpg.imageCatalogRef.major }}
     name: {{ .Values.postgres.cnpg.imageCatalogRef.name }}
   

--- a/helm/reports-server/templates/vpa.yaml
+++ b/helm/reports-server/templates/vpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" -}}
+{{- if .Values.vpa.enabled -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "reports-server.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "reports-server.labels" . | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Chart.Name }}
+    {{- if .Values.vpa.containerPolicies }}
+      {{- with .Values.vpa.containerPolicies -}}
+        {{ tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+    {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "reports-server.fullname" . }}
+  updatePolicy:
+    updateMode: Auto
+{{- end -}}
+{{- end -}}

--- a/helm/reports-server/values.yaml
+++ b/helm/reports-server/values.yaml
@@ -22,6 +22,13 @@ reports-server:
     debug: false
     db:
       secretName: "reports-server-app"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 postgres:
   cnpg:
@@ -39,3 +46,9 @@ postgres:
       major: 16
       name: gs-postgresql
     switchoverDelay: 60
+
+vpa:
+  enabled: true
+  containerPolicies:
+    minAllowed:
+      cpu: "100m"

--- a/helm/reports-server/values.yaml
+++ b/helm/reports-server/values.yaml
@@ -35,3 +35,9 @@ postgres:
       podMonitor:
         enabled: true
         labels: {}
+    imageCatalogRef:
+      apiGroup: postgresql.cnpg.io
+      kind: ImageCatalog
+      major: 16
+      name: gs-postgresql
+    switchoverDelay: 60

--- a/helm/reports-server/values.yaml
+++ b/helm/reports-server/values.yaml
@@ -36,8 +36,6 @@ postgres:
         enabled: true
         labels: {}
     imageCatalogRef:
-      apiGroup: postgresql.cnpg.io
-      kind: ImageCatalog
       major: 16
       name: gs-postgresql
     switchoverDelay: 60


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30093

This PR:

- uses an ImageCatalog to use GS-retagged images
- lowers the normal and failover case shutdown delays. This makes the postgres cluster fail over faster, but will potentially lose data. We aren't currently concerned about that, because this database is understood to contain ephemeral data which will be re-created from the cluster state.
- adds default resources and VPA

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
